### PR TITLE
tomato: Add assertions on baseband version

### DIFF
--- a/board-info.txt
+++ b/board-info.txt
@@ -1,1 +1,2 @@
 require version-trustzone=TZ.BF.3.0.R2-00034
+require version-baseband=1.0.2.C1-00096


### PR DESCRIPTION
* Only flash on allowed baseband
* Since YU5510A model release, there's a lot of confusion
  and people are trying to flash its firmware (by replacing it in ZIPs)
  on a regular AO5510/YU5510, which leads to dead devices.
* YU Forums Official Warning : http://forums.yuplaygod.com/threads/44176/

Change-Id: I16f781955d79b1178b2a5e9d299223a7e4a9310e
Signed-off-by: Louis Popi <theh2o64@gmail.com>